### PR TITLE
#1 [FEAT] 게시물 생성 API

### DIFF
--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/ControllerExceptionAdvice.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/ControllerExceptionAdvice.java
@@ -1,0 +1,20 @@
+package com.sopt.instagram.InstagramSERVER.common;
+
+import com.sopt.instagram.InstagramSERVER.common.dto.ApiResponseDto;
+import com.sopt.instagram.InstagramSERVER.exception.ErrorStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class ControllerExceptionAdvice {
+
+    /*
+     * 400 BAD_REQUEST
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ApiResponseDto handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        return ApiResponseDto.error(ErrorStatus.VALIDATION_EXCEPTION);
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/ControllerExceptionAdvice.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/ControllerExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.sopt.instagram.InstagramSERVER.common;
 
 import com.sopt.instagram.InstagramSERVER.common.dto.ApiResponseDto;
+import com.sopt.instagram.InstagramSERVER.exception.BusinessException;
 import com.sopt.instagram.InstagramSERVER.exception.ErrorStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,5 +17,10 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ApiResponseDto handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         return ApiResponseDto.error(ErrorStatus.VALIDATION_EXCEPTION);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ApiResponseDto handleBusinessException(final BusinessException e) {
+        return ApiResponseDto.error(e.getErrorStatus());
     }
 }

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
@@ -1,5 +1,6 @@
 package com.sopt.instagram.InstagramSERVER.common.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sopt.instagram.InstagramSERVER.exception.ErrorStatus;
 import com.sopt.instagram.InstagramSERVER.exception.SuccessStatus;
 import static lombok.AccessLevel.PRIVATE;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 @AllArgsConstructor(access = PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponseDto<T> {
 
     private final int code;

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
@@ -2,14 +2,15 @@ package com.sopt.instagram.InstagramSERVER.common.dto;
 
 import com.sopt.instagram.InstagramSERVER.exception.ErrorStatus;
 import com.sopt.instagram.InstagramSERVER.exception.SuccessStatus;
-import lombok.AccessLevel;
+import static lombok.AccessLevel.PRIVATE;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class ApiResponseDto<T> {
 
     private final int code;

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/common/dto/ApiResponseDto.java
@@ -1,0 +1,31 @@
+package com.sopt.instagram.InstagramSERVER.common.dto;
+
+import com.sopt.instagram.InstagramSERVER.exception.ErrorStatus;
+import com.sopt.instagram.InstagramSERVER.exception.SuccessStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponseDto<T> {
+
+    private final int code;
+    private final boolean success;
+    private final String message;
+    private T data;
+
+    public static ApiResponseDto success(SuccessStatus successStatus) {
+        return new ApiResponseDto<>(successStatus.getHttpStatus().value(), true, successStatus.getMessage());
+    }
+
+    public static <T> ApiResponseDto<T> success(SuccessStatus successStatus, T data) {
+        return new ApiResponseDto<T>(successStatus.getHttpStatus().value(), true, successStatus.getMessage(), data);
+    }
+
+    public static ApiResponseDto error(ErrorStatus errorStatus) {
+        return new ApiResponseDto<>(errorStatus.getHttpStatus().value(), false, errorStatus.getMessage());
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/BusinessException.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/BusinessException.java
@@ -1,0 +1,10 @@
+package com.sopt.instagram.InstagramSERVER.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BusinessException extends RuntimeException {
+    private final ErrorStatus errorStatus;
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/ErrorStatus.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/ErrorStatus.java
@@ -1,0 +1,25 @@
+package com.sopt.instagram.InstagramSERVER.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorStatus {
+
+    /*
+    BAD_REQUEST
+     */
+    VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    /*
+    SERVER_ERROR
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/ErrorStatus.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/ErrorStatus.java
@@ -18,6 +18,11 @@ public enum ErrorStatus {
     SERVER_ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
+
+    /*
+    NOT_FOUND
+     */
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/SuccessStatus.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/exception/SuccessStatus.java
@@ -1,0 +1,20 @@
+package com.sopt.instagram.InstagramSERVER.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessStatus {
+
+    /*
+    post
+     */
+    POST_CREATE_SUCCESS(HttpStatus.CREATED, "게시물 생성 완료"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/domain/Member.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/domain/Member.java
@@ -1,0 +1,25 @@
+package com.sopt.instagram.InstagramSERVER.member.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String profileUrl;
+
+    public void setDefaultImage() {
+        this.profileUrl = "https://imson.imweb.me/common/img/default_profile.png";
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/repository/MemberRepository.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.sopt.instagram.InstagramSERVER.member.repository;
+
+
+import com.sopt.instagram.InstagramSERVER.member.domain.Member;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends Repository<Member, Long> {
+
+    Optional<Member> findById(Long id);
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/service/MemberService.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/service/MemberService.java
@@ -1,10 +1,13 @@
 package com.sopt.instagram.InstagramSERVER.member.service;
 
+import com.sopt.instagram.InstagramSERVER.exception.BusinessException;
 import com.sopt.instagram.InstagramSERVER.member.repository.MemberRepository;
 import com.sopt.instagram.InstagramSERVER.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.sopt.instagram.InstagramSERVER.exception.ErrorStatus.MEMBER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,6 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member getMember() {
         return memberRepository.findById(1L)
-                .orElseThrow(() -> new RuntimeException("해당 멤버가 없습니다."));
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
     }
 }

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/service/MemberService.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.sopt.instagram.InstagramSERVER.member.service;
+
+import com.sopt.instagram.InstagramSERVER.member.repository.MemberRepository;
+import com.sopt.instagram.InstagramSERVER.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Member getMember() {
+        return memberRepository.findById(1L)
+                .orElseThrow(() -> new RuntimeException("해당 멤버가 없습니다."));
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/controller/PostController.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/controller/PostController.java
@@ -1,0 +1,27 @@
+package com.sopt.instagram.InstagramSERVER.post.controller;
+
+import com.sopt.instagram.InstagramSERVER.common.dto.ApiResponseDto;
+import com.sopt.instagram.InstagramSERVER.post.service.PostService;
+import com.sopt.instagram.InstagramSERVER.post.controller.dto.PostCreateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.sopt.instagram.InstagramSERVER.exception.SuccessStatus.POST_CREATE_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/api/post")
+    public ApiResponseDto create(@RequestBody @Valid final PostCreateDto postCreateDto) {
+        postService.create(postCreateDto);
+
+        return ApiResponseDto.success(POST_CREATE_SUCCESS);
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/controller/dto/PostCreateDto.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/controller/dto/PostCreateDto.java
@@ -1,0 +1,15 @@
+package com.sopt.instagram.InstagramSERVER.post.controller.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostCreateDto {
+
+    private String content;
+    private ArrayList<String> imageUrlList;
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/Post.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/Post.java
@@ -5,10 +5,8 @@ import lombok.*;
 
 import javax.persistence.*;
 
-@Builder
 @Getter
 @Entity
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
@@ -22,4 +20,10 @@ public class Post {
     private Member member;
 
     private String content;
+
+    @Builder
+    public Post(Member member, String content) {
+        this.member = member;
+        this.content = content;
+    }
 }

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/Post.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/Post.java
@@ -1,0 +1,25 @@
+package com.sopt.instagram.InstagramSERVER.post.domain;
+
+import com.sopt.instagram.InstagramSERVER.member.domain.Member;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private String content;
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/PostImage.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/PostImage.java
@@ -1,0 +1,29 @@
+package com.sopt.instagram.InstagramSERVER.post.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    public PostImage(Post post, String url) {
+        this.post = post;
+        this.imageUrl = url;
+    }
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/PostImage.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/domain/PostImage.java
@@ -22,6 +22,7 @@ public class PostImage {
     @Column(nullable = false)
     private String imageUrl;
 
+    @Builder
     public PostImage(Post post, String url) {
         this.post = post;
         this.imageUrl = url;

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/repository/PostImageRepository.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/repository/PostImageRepository.java
@@ -1,0 +1,9 @@
+package com.sopt.instagram.InstagramSERVER.post.repository;
+
+import com.sopt.instagram.InstagramSERVER.post.domain.PostImage;
+import org.springframework.data.repository.Repository;
+
+public interface PostImageRepository extends Repository<PostImage, Long> {
+
+    void save(PostImage postImage);
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/repository/PostRepository.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.sopt.instagram.InstagramSERVER.post.repository;
+
+import com.sopt.instagram.InstagramSERVER.post.domain.Post;
+import org.springframework.data.repository.Repository;
+
+public interface PostRepository extends Repository<Post, Long> {
+
+    void save(Post post);
+
+}

--- a/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/service/PostService.java
+++ b/Instagram-SERVER/src/main/java/com/sopt/instagram/InstagramSERVER/post/service/PostService.java
@@ -1,0 +1,36 @@
+package com.sopt.instagram.InstagramSERVER.post.service;
+
+import com.sopt.instagram.InstagramSERVER.member.service.MemberService;
+import com.sopt.instagram.InstagramSERVER.post.controller.dto.PostCreateDto;
+import com.sopt.instagram.InstagramSERVER.post.domain.Post;
+import com.sopt.instagram.InstagramSERVER.post.domain.PostImage;
+import com.sopt.instagram.InstagramSERVER.post.repository.PostImageRepository;
+import com.sopt.instagram.InstagramSERVER.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public void create(PostCreateDto postCreateDto) {
+
+        Post newPost = Post.builder()
+                .content(postCreateDto.getContent())
+                .member(memberService.getMember()).build();
+
+        List<PostImage> postImageList = postCreateDto.getImageUrlList().stream()
+                .map(url -> new PostImage(newPost, url)).collect(Collectors.toList());
+
+        postRepository.save(newPost);
+        postImageList.stream().forEach(postImage -> postImageRepository.save(postImage));
+    }
+}


### PR DESCRIPTION
## 🖇 Related Issue
- close #1 

## ✏️ Contents
- member entity 구현 및 고정 멤버(id=1) 찾아오기 구현
- post, postImage entity 구현 및 게시물 생성 기능 구현


## 📝 PR Point
- 데이터 값 따로 없을 시 null 값 주지 말고 아예 필드 주지 말자고 했는데, 그렇게 하려면 지금 response 줄 때 공통으로 쓰고 있는 ApiResponseDto말고 따로 하나 더 만드는 게 좋을까?!
- member가 프로필 이미지를 꼭 가질 필요는 없어서 null허용해서 저장하고 조회할 때 만약 프로필 이미지가 null값이면 member.setDefaultImage()로 기본이미지 설정해주고자 저 함수 만들어 놨는데, 이거 어떤지...?


## 📷 Screenshot

